### PR TITLE
Pitches: Add language-background pitch for C

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,6 +12,7 @@
     - [Embedded devices](pitches/applications/embedded.md)
     - [Command-line apps](pitches/applications/cli.md)
   - [Tailored by language background](pitches/background.md)
+    - [For C hackers](pitches/background/c.md)
     - [For C++ hackers](pitches/background/cpp.md)
     - [For JS/Python/Ruby devs](pitches/background/scripting.md)
     - [For Go/Swift/Java/C# devs](pitches/background/typed.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -21,6 +21,7 @@
   - [C](comparisons/c.md)
 - [Rebuttals](rebuttals.md)
   - [Only for maximal speed](rebuttals/only-speed.md)
+  - [Only for systems programming](rebuttals/only-systems.md)
   - [Only for avoiding GC](rebuttals/only-gc.md)
   - [Tied to Mozilla](rebuttals/mozilla.md)
 - [Notable achievements](achievements.md)

--- a/src/pitches/background/c.md
+++ b/src/pitches/background/c.md
@@ -1,0 +1,1 @@
+# For C hackers

--- a/src/rebuttals/only-systems.md
+++ b/src/rebuttals/only-systems.md
@@ -1,0 +1,1 @@
+# Only for systems programming


### PR DESCRIPTION
C and C++ have distinct audiences, and we should address them
differently.